### PR TITLE
fix `mBH_min` to minimum final BH mass

### DIFF
--- a/ssptools/ifmr.py
+++ b/ssptools/ifmr.py
@@ -57,7 +57,7 @@ class IFMR:
         self.BH_spline = UnivariateSpline(bh_mi, bh_mf, s=0, k=1)
 
         self.m_min = bh_mi[0]
-        self.mBH_min = self.predict(self.m_min)
+        self.mBH_min = np.min(bh_mf)
 
     def _check_feh_bounds(self):
 


### PR DESCRIPTION
Sets the minimum mass of BHs explicitly to the smallest final BH mass in the IFMR spline, rather than predicting it based on the initial stellar mass, as this does not translate to the smallest BH in the latest IFMRs.