### PR TITLE
fix divide-by-zero bug in `Pk` helper function

### DIFF
--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -265,6 +265,7 @@ class EvolvedMF:
 
         self._evolve()
 
+    @np.errstate(invalid='ignore')
     def _Pk(self, a, k, m1, m2):
         r'''Convenience function for computing quantities related to IMF
 
@@ -293,11 +294,14 @@ class EvolvedMF:
         m1, m2 : float
             Upper and lower bound of given mass bin or range
         '''
-        try:
-            return (m2 ** (a + k) - m1 ** (a + k)) / (a + k)
 
-        except ZeroDivisionError:
-            return np.log(m2 / m1)
+        a = np.asarray(a)
+        res = np.asarray((m2 ** (a + k) - m1 ** (a + k)) / (a + k))  # a != k
+
+        if (casemask := np.asarray(-a == k)).any():
+            res[casemask] = np.log(m2 / m1)[casemask]
+
+        return res
 
     def _set_imf(self, m_break, a, nbin, N0):
         '''Initialize the mass bins based on the IMF and initial number of stars

--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -295,7 +295,7 @@ class EvolvedMF:
             Upper and lower bound of given mass bin or range
         '''
 
-        a = np.asarray(a)
+        a = np.asarray(a, dtype=float)
         res = np.asarray((m2 ** (a + k) - m1 ** (a + k)) / (a + k))  # a != k
 
         if (casemask := np.asarray(-a == k)).any():

--- a/tests/test_evolve_mf.py
+++ b/tests/test_evolve_mf.py
@@ -111,7 +111,7 @@ class TestHelperMethods:
     # ----------------------------------------------------------------------
 
     @pytest.mark.parametrize('k', [1., 1.5, 2.])
-    @pytest.mark.parametrize('a', [-1., -0.5, 1.0])
+    @pytest.mark.parametrize('a', [-2, -1., -0.5, 1.0])
     def test_Pk(self, a, k):
         from scipy.integrate import quad
 


### PR DESCRIPTION
`Pk` is a helper function representing the analytic solution of the integral over the mass. This solution takes a different form when `a == k`, as the typical solution would have a divide by zero error.

The previous fix for this assumed a couple erroneous things; firstly that one or the other solution would be valid for all inputs submitted to the method in a single call, and secondly that, when called on arrays, numpy would raise a divide by zero array, rather than just giving a nan.

This commit adds a more robust, but hopefully still efficient, fix.

This fix works by first computing the typical solution for all, even when it errors (thus the ignore warnings). This requires coercing all inputs to numpy arrays or floats, to avoid the base python `ZeroDivisionError`.
Then the other solution is used to fill in any gaps where `a==k`, if it is necessary (it usually isn't).