### PR TITLE
Feature/initial bhs

### DIFF
--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -734,7 +734,7 @@ class EvolvedMF:
                 #   is not ideal
 
                 # Check if any BH have been created
-                if ti > self.compute_tms(self.IFMR.BH_mi.lower):
+                if ti > self.compute_tms(self.IFMR.BH_mi.upper):
 
                     # calculate total mass we want to eject
                     M_eject = Mr.BH.sum() * (1.0 - self.BH_ret_dyn)
@@ -1002,7 +1002,7 @@ class EvolvedMFWithBH(EvolvedMF):
                 # ----------------------------------------------------------
 
                 # Check if any BH have been created
-                if ti > self.compute_tms(self.IFMR.BH_mi.lower):
+                if ti > self.compute_tms(self.IFMR.BH_mi.upper):
 
                     fBH_target = self._fBH_target[iout]
 

--- a/ssptools/masses.py
+++ b/ssptools/masses.py
@@ -263,6 +263,7 @@ class MassBins:
 
             nbin_WD = WD_mask.sum()
 
+            # TODO fails if m_break[0] < ifmr.WD_mf.upper
             bins_WD = mbin(bins_MS.lower[WD_mask].copy(),
                            bins_MS.upper[WD_mask].copy())
             bins_WD.upper[-1] = ifmr.WD_mf.upper

--- a/ssptools/masses.py
+++ b/ssptools/masses.py
@@ -276,7 +276,7 @@ class MassBins:
 
             bins_BH = mbin(bins_MS.lower[BH_mask].copy(),
                            bins_MS.upper[BH_mask].copy())
-            bins_BH.upper[0] = ifmr.BH_mf.lower
+            bins_BH.lower[0] = ifmr.BH_mf.lower
 
             # Neutron Stars
 
@@ -344,12 +344,13 @@ class MassBins:
 
         A3 = (
             Pk(a[2], 1, mb[2], mb[3])
-            + (mb[1] ** (a[1] - a[0]) * Pk(a[0], 1, mb[0], mb[1]))
             + (mb[2] ** (a[2] - a[1]) * Pk(a[1], 1, mb[1], mb[2]))
-        ) ** (-1)
+            + (mb[1] ** (a[1] - a[0]) * (mb[2] ** (a[2] - a[1]))
+               * Pk(a[0], 1, mb[0], mb[1]))
+        )**(-1)
 
-        A2 = A3 * mb[2] ** (a[2] - a[1])
-        A1 = A2 * mb[1] ** (a[1] - a[0])
+        A2 = A3 * mb[2]**(a[2] - a[1])
+        A1 = A2 * mb[1]**(a[1] - a[0])
 
         A = self.N0 * np.repeat([A1, A2, A3], self._nbin_MS_each)
 

--- a/tests/test_masses.py
+++ b/tests/test_masses.py
@@ -166,7 +166,7 @@ class TestMassIndices:
             (1., 'MS', 2),
             (1., 'WD', 2),
             (1., 'NS', 0),
-            (1., 'BH', 0),
+            (DEFAULT_KWARGS['ifmr'].BH_mf.lower, 'BH', 0),
             (99., 'BH', 1),
             (2., masses.mbin(*np.array([[1, 2, 3], [2, 3, 4]])), 1)
         ]


### PR DESCRIPTION
Adds a new class to `evolve_mf` which is meant to focus the analysis of the evolved mass functions only on the initially created black hole populations, essentially by stopping the evolution once all BHs are created and simplifying the differential equations involved correspondingly to speed it up.

Overall just provides a much simpler and quicker way to look at the BH populations created by the mass functions.