### PR TITLE
Feature/kicks redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ import ssptools
 
 m_break, a_slopes, nbins = [0.08, 0.5, 150.], [+1.3, -2.3], [5, 30]
 pdmf = ssptools.EvolvedMF.from_powerlaw(m_break, a_slopes, nbins,
-                                        FeH=-1.5, tout=13000, Ndot=0, N0=1e6)
+                                        FeH=-1.5, tout=13000, esc_rate=0, N0=1e6)
 ```
 
 Alternatively, an IMF class can be instantiated and used directly:
 
 ```python
 imf = ssptools.masses.PowerLawIMF(m_break, a_slopes, N0=1e6)
-pdmf = ssptools.EvolvedMF(imf, nbins, FeH=-1.5, tout=[0, 1000, 13000], Ndot=0)
+pdmf = ssptools.EvolvedMF(imf, nbins, FeH=-1.5, tout=[0, 1000, 13000], esc_rate=0)
 ```
 
 See the documentation of each class for more details on all possible parameters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "astro-ssptools"
-version = "2.1.4"
+version = "3.0.0"
 description = "Simple Stellar Population Tools"
 authors = [
     {name = "Eduardo Balbinot", email = "eduardo.balbinot@gmail.com"},
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Astronomy",

--- a/ssptools/__init__.py
+++ b/ssptools/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Eduardo Balbinot"""
 __email__ = "eduardo.balbinot@gmail.com"
-__version__ = "2.1.4"
+__version__ = "3.0.0"
 
 from .evolve_mf import *
 from .sev import *

--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -1362,40 +1362,8 @@ class InitialBHPopulation:
         '''The total mass fraction in BHs, given a total population mass.'''
         return self.Mtot / M_cluster
 
-    def __init__(self, M_BH, N_BH, BH_bins, FeH, *,
-                 natal_kicks=False, kick_method='maxwellian', f_kick=None,
-                 SNe_method='rapid', vesc=90, kick_vdisp=265.,
-                 kick_slope=1, kick_scale=20):
+    def __init__(self, M_BH, N_BH, BH_bins):
         '''Should not init from this, use provided classmethods.'''
-
-        # ------------------------------------------------------------------
-        # Optionally perform all natal kicks on the input mass arrays
-        # ------------------------------------------------------------------
-
-        if natal_kicks:
-
-            self.natal_kicks = natal_kicks
-
-            match kick_method.casefold():
-
-                case 'maxwellian' | 'f12' | 'fryer2012':
-
-                    from .ifmr import _check_IFMR_FeH_bounds
-                    FeH_BH = _check_IFMR_FeH_bounds(FeH)
-
-                    kick_kw = dict(method=kick_method, f_kick=f_kick, vesc=vesc,
-                                   FeH=FeH_BH, vdisp=kick_vdisp,
-                                   SNe_method=SNe_method)
-
-                case 'sigmoid' | 'tanh':
-                    kick_kw = dict(method=kick_method, f_kick=f_kick,
-                                   slope=kick_slope, scale=kick_scale)
-
-                case _:
-                    mssg = f"Invalid natal kick algorithm '{kick_method=}'"
-                    raise ValueError(mssg)
-
-            *_, self._kick_stats = kicks.natal_kicks(M_BH, N_BH, **kick_kw)
 
         # ------------------------------------------------------------------
         # Compute and store all final BH mass and number arrays and values
@@ -1419,10 +1387,14 @@ class InitialBHPopulation:
     # ----------------------------------------------------------------------
 
     @classmethod
-    def from_IMF(cls, IMF, nbins, FeH, N0=5e5, *, natal_kicks=True,
-                 binning_breaks=None, binning_method='default',
+    def from_IMF(cls, IMF, FeH, *, natal_kicks=True,
+                 kick_method='maxwellian', f_kick=None,
+                 SNe_method='rapid', vesc=90, kick_vdisp=265.,
+                 kick_slope=1, kick_scale=20,
                  BH_IFMR_method='banerjee20', WD_IFMR_method='mist18',
-                 BH_IFMR_kwargs=None, WD_IFMR_kwargs=None, **kwargs):
+                 BH_IFMR_kwargs=None, WD_IFMR_kwargs=None,
+                 bins=None, nbins=[5, 5, 20],
+                 binning_breaks=None, binning_method='default', **kwargs):
         '''Initialize a BH population by evolving from an IMF.
 
         Based on a given IMF, sharing many arguments with `EvolvedMF`, generate
@@ -1448,17 +1420,35 @@ class InitialBHPopulation:
         FeH : float
             Metallicity, in solar fraction [Fe/H].
 
-        N0 : int, optional
-            Total initial number of stars, over all bins.
-            If None, uses the N0 of the given IMF class. Defaults to 5e5 stars.
-
         natal_kicks : bool, optional
             Whether to account for natal kicks in the BH dynamical retention.
             Defaults to True (note this difference from `EvolvedMF`).
 
+        kick_method : {'maxwellian', 'tanh', 'sigmoid'}, optional
+            The BH natal kick algorithm to use, if `natal_kicks=True`.
+            See `kicks` for more details.
+
         vesc : float, optional
             Initial cluster escape velocity, in km/s, for use in the
             computation of BH natal kick effects. Defaults to 90 km/s.
+
+        kick_vdisp : float, optional
+            The dispersion of the Maxwellian natal kick velocity distribution.
+            Only used if `kick_method='maxwellian'`.
+            See `kicks._maxwellian_retention_frac` for more information.
+
+        f_kick : float, optional
+
+        kick_slope : float
+            The "slope" of the sigmoid retention function, defining the
+            "sharpness" of the increase. Only used if `kick_method='sigmoid'`.
+            See `kicks._sigmoid_retention_frac` for more information.
+
+        kick_scale : float
+            The scale-mass of the sigmoid retention function, defining the
+            approximate mass of the turn-over from 0 to 1.
+            Only used if `kick_method='sigmoid'`.
+            See `kicks._sigmoid_retention_frac` for more information.
 
         binning_breaks : list of float, optional
             The binning break masses to use when constructing the mass bins,
@@ -1490,81 +1480,6 @@ class InitialBHPopulation:
             All other arguments are passed to the `InitialBHPopulation`.
         '''
 
-        def compute_tms(mi):
-            a = tms_constants
-            return a[0] * np.exp(a[1] * mi ** a[2])
-
-        def compute_mto(t):
-            a0, a1, a2 = tms_constants
-            if t > a0:
-                return (np.log(t / a0) / a1) ** (1 / a2)
-            else:
-                return np.inf
-
-        def _derivs_BHs(t, y):
-            '''Derivatives relevant to mass changes due to stellar evolution.
-            This is a massively simplified case of the DEs from `EvolvedMF`,
-            and is only valid up to the age all BHs are formed.
-            `y` is [MS N array, BH N array, BH M array].
-            '''
-
-            # Setup derivative bins
-            Ns = y[:nbin_MS]  # only Ns is relevant right now
-            dNs = np.zeros(nbin_MS)
-            dNr, dMr = np.zeros(nbin_BH), np.zeros(nbin_BH)
-
-            frem = 1.0  # Retain all BHs
-
-            # Apply only if this time is atleast later than the earliest tms
-            if t > tms_u[-1]:
-
-                # Find out which mass bin is the current turn-off bin
-                isev = np.where(t > tms_u)[0][0]
-
-                mto, m1 = compute_mto(t), massbins.bins.MS.lower[isev]
-
-                # Avoid "hitting" the bin edge
-                if mto > m1 and (Nj := Ns[isev]) > 0.1:
-
-                    # The normalization constant
-                    # TODO deal with the constant divide-by-zero warning here
-                    Aj = Nj / Pk(IMF.a[-1], 1, m1, mto)
-
-                    # Get the number of turn-off stars per unit of mass
-                    dNdm = Aj * mto**IMF.a[-1]
-
-                else:
-                    dNdm = 0
-                    # TODO just break???
-
-                # Compute the full dN/dt = dN/dm * dm/dt
-                a = tms_constants
-                dmdt = abs((1.0 / (a[1] * a[2] * t))
-                           * (np.log(t / a[0]) / a[1]) ** (1 / a[2] - 1))
-
-                dNdt = -dNdm * dmdt
-
-                # Fill in star derivatives
-                dNs[isev] = dNdt
-
-                # Skip 0-mass remnants
-                if t <= final_age and (m_rem := _ifmr.predict(mto)) > 0:
-
-                    # If this happens its because IFMR is (numerically) broken!
-                    if (cls_rem := _ifmr.predict_type(mto)) != 'BH':
-                        mssg = f"Initial mass {mto} made a {cls_rem}, not a BH."
-                        raise RuntimeError(mssg)
-
-                    # Find bin based on lower bin edge (must be careful later)
-
-                    irem = massbins.determine_index(m_rem, cls_rem)
-
-                    # Fill in remnant derivatives
-                    dNr[irem] = -dNdt * frem
-                    dMr[irem] = -m_rem * dNdt * frem
-
-            return np.r_[dNs, dNr, dMr]
-
         # ------------------------------------------------------------------
         # Initialise the initial mass function and mass bins given the
         # power-law IMF slopes and bins
@@ -1575,64 +1490,113 @@ class InitialBHPopulation:
 
         binning_breaks = IMF.mb if binning_breaks is None else binning_breaks
 
-        massbins = MassBins(binning_breaks, nbins, IMF, _ifmr,
-                            binning_method=binning_method)
+        if bins is None:
+            # TODO it now makes more sense to have nbins be just the number of
+            # BH bins, should maybe remove some options
+            massbins = MassBins(binning_breaks, nbins, IMF, _ifmr,
+                                binning_method=binning_method)
 
-        nbin_MS, nbin_BH = massbins.nbin.MS, massbins.nbin.BH
+            bins = massbins.bins.BH
 
-        # Load a_i coefficients derived from interpolated Dartmouth models
-        mstogrid = np.loadtxt(get_data("sevtables/msto.dat"))
-        nearest_FeH = np.argmin(np.abs(mstogrid[:, 0] - FeH))
-        tms_constants = mstogrid[nearest_FeH, 1:]
-
-        # Compute t_ms for all bin edges
-        tms_u = compute_tms(massbins.bins.MS.upper)
-
-        init_N, init_M = massbins.initial_values(packed=False, N0=N0)
+        nbin_BH = bins.lower.size
 
         # ------------------------------------------------------------------
-        # Integrate and solve the derivatives (evolve)
+        # Compute the initial amounts of BHs expected from the IMF and IFMR
         # ------------------------------------------------------------------
 
-        y0 = np.r_[init_N.MS, init_N.BH, init_M.BH]
+        # Get domain of progenitor masses that make BHs
+        mi = np.linspace(*_ifmr.BH_mi, 50_000)
+        dm = mi[1] - mi[0]
 
-        sol = ode(_derivs_BHs)
-        sol.set_integrator("dopri5", max_step=1e12, atol=1e-5, rtol=1e-5)
-        sol.set_initial_value(y0, t=0.0)
+        # Determine the final BH masses
+        mf = _ifmr.predict(mi)
 
-        final_age = compute_tms(_ifmr.BH_mi.lower + 0.1)  # fltpnt bound errors
+        # Determine which BH bin each BH will fall into
+        # TODO this may be behaving weird when out of bounds? (!)
+        inds = np.digitize(mf, np.r_[bins.lower, bins.upper[-1]]) - 1
 
-        # Integrate the solver at each bin bound, to match EvolvedMF.
-        # The ODE solvers are suspiciously sensitive to this, and while this
-        # may not be the most sane solution, this will recreate EvolvedMF.
-        for ti in np.sort(tms_u[tms_u < final_age]):
-            sol.integrate(ti)
+        # Optionally perform natal kicks
+        if natal_kicks:
 
-        sol.integrate(final_age)
+            match kick_method.casefold():
 
-        N_BH, M_BH = sol.y[nbin_MS:nbin_MS + nbin_BH], sol.y[nbin_MS + nbin_BH:]
+                case 'maxwellian' | 'f12' | 'fryer2012':
+
+                    from .ifmr import _check_IFMR_FeH_bounds
+                    FeH_BH = _check_IFMR_FeH_bounds(FeH)
+
+                    kick_kw = dict(method=kick_method, f_kick=f_kick, vesc=vesc,
+                                   FeH=FeH_BH, vdisp=kick_vdisp,
+                                   SNe_method=SNe_method)
+
+                case 'sigmoid' | 'tanh':
+                    kick_kw = dict(method=kick_method, f_kick=f_kick,
+                                   slope=kick_slope, scale=kick_scale)
+
+                case _:
+                    mssg = f"Invalid natal kick algorithm '{kick_method=}'"
+                    raise ValueError(mssg)
+
+            frem = kicks.kick_retention_fraction(mi, **kick_kw)
+
+        else:
+            frem = 1.0
+
+        # Compute the masses and numbers of BHs which will form
+
+        M_BH = np.bincount(inds, weights=frem * mf * IMF.N(mi) * dm,
+                           minlength=nbin_BH)
+
+        N_BH = np.bincount(inds, weights=frem * IMF.N(mi) * dm,
+                           minlength=nbin_BH)
 
         # ------------------------------------------------------------------
         # Create the final class instance, and populate some extra values
         # specific to this init method, related to the evolution
         # ------------------------------------------------------------------
 
-        out = cls(M_BH, N_BH, massbins.bins.BH,
-                  FeH=FeH, natal_kicks=natal_kicks, **kwargs)
+        out = cls(M_BH, N_BH, bins)
+
+        # Helpful classes
 
         out.IMF = IMF
+        out.IFMR = _ifmr
 
-        out.age = final_age
+        # Natal kicks
 
-        Ns = sol.y[:nbin_MS]
+        out.natal_kicks = natal_kicks
 
-        alphas = np.repeat(IMF.a, massbins._nbin_MS_each)
-        As = Ns / Pk(alphas, 1, *massbins.bins.MS)
-        Ms = As * Pk(alphas, 2, *massbins.bins.MS)
+        if natal_kicks:
+
+            # Kinda crazy but I think we have to recompute this entirely
+            # without the kicks to get the difference.
+
+            M_BH_nokick = np.bincount(inds, weights=mf * IMF.N(mi) * dm,
+                                      minlength=nbin_BH)
+
+            N_BH_nokick = np.bincount(inds, weights=IMF.N(mi) * dm,
+                                      minlength=nbin_BH)
+
+            ibh_nokick = cls(M_BH_nokick, N_BH_nokick, bins)
+
+            out._kick_stats = kicks.KickStats.from_final(M_BH, N_BH, ibh_nokick,
+                                                         parameters=kick_kw)
+
+        else:
+
+            out._kick_stats = kicks.KickStats.no_kicks(nbin_BH)
+
+        # Compute the final age (i.e. compute_tms())
+
+        mstogrid = np.loadtxt(get_data("sevtables/msto.dat"))
+        nearest_FeH = np.argmin(np.abs(mstogrid[:, 0] - FeH))
+        a = mstogrid[nearest_FeH, 1:]
+        out.age = a[0] * np.exp(a[1] * _ifmr.BH_mi.lower ** a[2])
 
         # Stellar losses
-        out.Ns_lost = init_N.MS.sum() - Ns.sum()
-        out.Ms_lost = init_M.MS.sum() - Ms.sum()
+
+        out.Ns_lost = IMF.integrate_N(*_ifmr.BH_mi)  # number of stars now BHs
+        out.Ms_lost = IMF.integrate_M(*_ifmr.BH_mi)  # mass of stars lost to BHs
 
         return out
 
@@ -1700,17 +1664,19 @@ class InitialBHPopulation:
 
     @classmethod
     def from_BHMF(cls, m_breaks, a_slopes, nbins, FeH, N0=1000, *,
-                  natal_kicks=True, binning_method='default',
+                  binning_method='default',
                   BH_IFMR_method='banerjee20', WD_IFMR_method='mist18',
-                  BH_IFMR_kwargs=None, WD_IFMR_kwargs=None, **kwargs):
+                  BH_IFMR_kwargs=None, WD_IFMR_kwargs=None):
         '''Initialize a BH population based on a given power-law mass function.
 
         Based on an explicit given power-law parametrization of a BH mass
         function, generate a corresponding population of BH mass bins.
         This class *does not* simulate any evolution, and is not based on
         any sort of stellar mass function, but simply creates bins of mass
-        (normalized to N0) for a given BH MF, and optionally provides
-        natal kicks.
+        (normalized to N0) for a given BH MF.
+
+        The IFMR kwargs are solely used to determine min and max BH masses for
+        creating the mass bins (depending on the binning methods used).
 
         Parameters
         ----------
@@ -1729,10 +1695,6 @@ class InitialBHPopulation:
 
         N0 : int, optional
             Total initial number of BHs, over all bins. Defaults to 1000 BHs.
-
-        natal_kicks : bool, optional
-            Whether to account for natal kicks in the BH dynamical retention.
-            Defaults to True (note this difference from `EvolvedMF`).
 
         vesc : float, optional
             Initial cluster escape velocity, in km/s, for use in the
@@ -1772,5 +1734,5 @@ class InitialBHPopulation:
 
         N_BH, M_BH, _ = MF.binned_eval(bins)
 
-        return cls(M_BH, N_BH, bins, FeH=FeH,
-                   natal_kicks=natal_kicks, **kwargs)
+        return cls(M_BH, N_BH, bins)
+

--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -23,8 +23,6 @@ class EvolvedMF:
     to a binned present-day mass function (PDMF) at a given set of ages, and
     computes the numbers and masses of stars and remnants in each mass bin.
 
-    # TODO add more in-depth explanation or references to actual algorithm here
-
     Parameters
     ----------
     IMF : PowerLawIMF
@@ -64,12 +62,10 @@ class EvolvedMF:
     NS_ret : float, optional
         Neutron star retention fraction (0 to 1). Defaults to 0.1 (10%).
 
-    BH_ret_int : float, optional
-        Initial black hole retention fraction (0 to 1). Defaults to 1 (100%).
-
     BH_ret_dyn : float, optional
-        Dynamical black hole retention fraction (0 to 1), including both
-        dynamical ejections and natal kicks. Defaults to 1 (100%).
+        Dynamical black hole retention fraction (0 to 1). Does not include the
+        natal kicks, only the a posteriori dynamical ejections.
+        Defaults to 1 (100%).
 
     natal_kicks : bool, optional
         Whether to account for natal kicks in the BH dynamical retention.
@@ -221,7 +217,7 @@ class EvolvedMF:
 
     Notes
     -----
-        The BH kicks and ejections are computed post facto on the BH mass
+        The dynamical ejections are computed after the fact on the BH mass
         bins for each requested output age (`tout`). As such, parameters such
         as `BH_ret_dyn` are applied equally at each age, and not accounted
         for during the evolution, which may not be entirely realistic.
@@ -289,7 +285,7 @@ class EvolvedMF:
         return (np.c_[self.Nr][-1] > 10 * self.Nmin).sum()
 
     def __init__(self, IMF, nbins, FeH, tout, esc_rate, N0=5e5,
-                 tcc=0.0, NS_ret=0.1, BH_ret_int=1.0, BH_ret_dyn=1.0, *,
+                 tcc=0.0, NS_ret=0.1, BH_ret_dyn=1.0, *,
                  natal_kicks=False, kick_method='maxwellian',
                  SNe_method='rapid', vesc=90, kick_vdisp=265., f_kick=None,
                  kick_slope=1, kick_scale=20,
@@ -320,9 +316,7 @@ class EvolvedMF:
         self._stellar_ev = stellar_evolution
 
         self.NS_ret = NS_ret
-        self.BH_ret_int = BH_ret_int
         self.BH_ret_dyn = BH_ret_dyn
-        self._frem = {'WD': 1., 'NS': NS_ret, 'BH': BH_ret_int}
 
         self.FeH = FeH
 
@@ -348,6 +342,16 @@ class EvolvedMF:
 
         self.massbins = MassBins(binning_breaks, nbins, self.IMF, self.IFMR,
                                  binning_method=binning_method)
+
+        # ------------------------------------------------------------------
+        # Compute the full initial BH mass function
+        # ------------------------------------------------------------------
+
+        self.ibh = InitialBHPopulation.from_IMF(
+            IMF, FeH=FeH, N0=N0, bins=self.massbins.bins.BH, natal_kicks=False,
+            WD_IFMR_method=WD_IFMR_method, WD_IFMR_kwargs=WD_IFMR_kwargs,
+            BH_IFMR_method=BH_IFMR_method, BH_IFMR_kwargs=BH_IFMR_kwargs,
+        )
 
         # ------------------------------------------------------------------
         # Setup lifetime approximations and compute t_ms of all bin edges
@@ -379,6 +383,19 @@ class EvolvedMF:
 
         self.natal_kicks = natal_kicks
 
+        # If f_kick, try to determine kick scale automatically
+        if f_kick is not None:
+            try:
+                kick_slope, kick_scale = kicks._determine_kick_params(
+                    kick_method, f_kick, self.IMF, self.IFMR,
+                    kick_slope, kick_scale
+                )
+
+            except TypeError as err:
+                mssg = (f"Can only use `f_kick` with methods that use "
+                        f"`scale` and `slope` params, not '{kick_method}'.")
+                raise ValueError(mssg) from err
+
         match kick_method.casefold():
 
             case 'maxwellian' | 'f12' | 'fryer2012':
@@ -387,13 +404,17 @@ class EvolvedMF:
                 FeH_BH = _check_IFMR_FeH_bounds(FeH)
 
                 self._kick_kw = dict(
-                    method=kick_method, f_kick=f_kick, vesc=vesc,
+                    method=kick_method, vesc=vesc,
                     FeH=FeH_BH, vdisp=kick_vdisp, SNe_method=SNe_method
                 )
 
             case 'sigmoid' | 'tanh':
-                self._kick_kw = dict(method=kick_method, f_kick=f_kick,
+
+                self._kick_kw = dict(method=kick_method,
                                      slope=kick_slope, scale=kick_scale)
+
+            case 'full' | 'everything' | 'all' | 'none':
+                self._kick_kw = dict(method=kick_method)
 
             case _:
                 mssg = f"Invalid natal kick algorithm '{kick_method=}'"
@@ -481,6 +502,31 @@ class EvolvedMF:
         out[~asympt] = np.inf
 
         return out
+
+    def _frem(self, mi, rem_type):
+        '''The *initial* retention fraction of a given remnant type.'''
+
+        match rem_type:
+
+            # White dwarfs, assume always 100% retained
+
+            case 'WD':
+                return 1.0
+
+            # Neutron stars, input `NS_ret`, default to constant 10%
+
+            case 'NS':
+                return self.NS_ret
+
+            # Black Holes, compute full natal kicks
+
+            case 'BH':
+
+                if self.natal_kicks:
+                    return kicks.kick_retention_fraction(mi, **self._kick_kw)
+
+                else:
+                    return 1.0
 
     def _derivs(self, t, y):
         '''Main function for computing derivatives relevant to mass evolution
@@ -579,7 +625,7 @@ class EvolvedMF:
                 irem = self.massbins.determine_index(m_rem, cls_rem)
 
                 # Compute Remnant retention fractions based on remnant type
-                frem = self._frem[cls_rem]
+                frem = self._frem(mto, cls_rem)
 
                 # Fill in remnant derivatives
                 getattr(dNr, cls_rem)[irem] = -dNdt * frem
@@ -683,6 +729,7 @@ class EvolvedMF:
 
         dNs[depl_mask] += B * Is
 
+        # TODO is B correct, given alpha is only for the stars??
         dalpha[depl_mask] += (
             B * ((bins_MS.lower[depl_mask] / md) ** 0.5
                  - (bins_MS.upper[depl_mask] / md) ** 0.5)
@@ -794,10 +841,6 @@ class EvolvedMF:
         self.rem_types = np.repeat(self.massbins.nbin._fields[1:],
                                    self.massbins.nbin[1:])
 
-        # To save some repetition, just note these stats here
-        if not self.natal_kicks:
-            self._kick_stats = kicks.KickStats.no_kicks(self.massbins.nbin.BH)
-
         # ------------------------------------------------------------------
         # Initialise ODE solver
         # ------------------------------------------------------------------
@@ -843,52 +886,60 @@ class EvolvedMF:
                 Ms = As * Pk(alpha, 2, *bins_MS)
 
                 # ----------------------------------------------------------
-                # Eject BHs, first through natal kicks, then dynamically
+                # Eject BHs
                 # ----------------------------------------------------------
                 # TODO really feels like this should be done during the
-                #   evolution/derivs? At least for the natal kicks.
+                #   evolution/derivs?
                 # TODO due to rem_classes tuple, ejections done in place, which
                 #   is not ideal
 
                 # Check if any BH have been created
                 if ti > self.compute_tms(self.IFMR.BH_mi.upper):
 
+                    # ------------------------------------------------------
+                    # Get BH natal kick statistics.
+                    # These are somewhat approximate, and also must be done
+                    # before the dynamical ejections so we can try to work out
+                    # how much mass was kicked before them.
+                    # ------------------------------------------------------
+
+                    if self.natal_kicks:
+
+                        # if not all BHs have formed yet, kick stats is invalid
+                        #  this is just due to how we now compute them using ibh
+                        if ((ti == self.tout[-1]) and (ti < self.ibh.age)):
+
+                            mssg = ("_kick_stats will not be valid for ages "
+                                    f"before all BHs form ({self.ibh.age} Myr)")
+                            warnings.warn(mssg)
+
+                        self._kick_stats = kicks.KickStats.from_final(
+                                Mr.BH, Nr.BH, self.ibh, parameters=self._kick_kw
+                            )
+
+                    else:
+
+                        self._kick_stats = kicks.KickStats.no_kicks(
+                            self.massbins.nbin.BH
+                        )
+
+                    # ------------------------------------------------------
+                    # Eject BHs dynamically, based on desired BH_ret_dyn
+                    # ------------------------------------------------------
+
                     # calculate total mass we want to eject
                     M_eject = Mr.BH.sum() * (1.0 - self.BH_ret_dyn)
+
                     M_ret = Mr.BH.sum() - M_eject
 
                     # If kicking basically all, skip ahead
                     if 0. <= M_ret / (Mr.BH[0] / Nr.BH[0]) < self.Nmin:
-
-                        # Compute the natal kicks, just to store the stats
-                        if self.natal_kicks:
-
-                            *_, self._kick_stats = kicks.natal_kicks(
-                                Mr.BH.copy(), Nr.BH.copy(), **self._kick_kw
-                            )
 
                         # Remove all BHs and skip ahead
                         Mr.BH[:] = 0
                         Nr.BH[:] = 0
 
                     else:
-
-                        # First remove mass from all bins by natal kicks
-                        if self.natal_kicks:
-
-                            *_, self._kick_stats = kicks.natal_kicks(
-                                Mr.BH, Nr.BH, **self._kick_kw
-                            )
-                            M_eject -= self._kick_stats.total_kicked
-
-                        if M_eject < 0:
-                            mssg = (
-                                f"Natal kicks already removed {-M_eject} Msun "
-                                "more than total ejections desired by "
-                                f"'BH_ret_dyn={self.BH_ret_dyn}'. "
-                                "Increase BH_ret_dyn or alter natal kicks."
-                            )
-                            raise ValueError(mssg)
 
                         # Remove dynamical BH ejections
                         self._dyn_eject_BH(Mr.BH, Nr.BH, M_eject=M_eject)
@@ -919,14 +970,21 @@ class EvolvedMF:
 
                     self.mr[c][iout, :] = mr
 
+        # ------------------------------------------------------------------
+        # Get some final helpful quantities
+        # ------------------------------------------------------------------
+
         Mtot = self.Ms.sum(axis=1) + np.c_[self.Mr].sum(axis=1)
         Ntot = self.Ns.sum(axis=1) + np.c_[self.Nr].sum(axis=1)
+        # TODO sometimes results in nan, because Ntot has nans?
         self.mmean = Mtot / Ntot
 
         self.converged = sol.successful()
         if not self.converged:
             mssg = "ODE solver has *not* converged, this MF will not be valid."
             warnings.warn(mssg)
+
+        self.sol = sol
 
 
 class EvolvedMFWithBH(EvolvedMF):
@@ -1012,7 +1070,7 @@ class EvolvedMFWithBH(EvolvedMF):
 
         self.strict_BH_target = strict_BH_target
 
-        # leave BH_ret_dyn as default, will be ignored. BH_ret_int is fine
+        # leave BH_ret_dyn as default, will be ignored.
         super().__init__(IMF, nbins, FeH, tout, esc_rate,
                          *args, **kwargs)
 
@@ -1225,26 +1283,44 @@ class EvolvedMFWithBH(EvolvedMF):
                 Ms = As * Pk(alpha, 2, *bins_MS)
 
                 # ----------------------------------------------------------
-                # Eject BHs, first through natal kicks, then dynamically
+                # Eject BHs
                 # ----------------------------------------------------------
 
                 # Check if any BH have been created
                 if ti > self.compute_tms(self.IFMR.BH_mi.upper):
 
-                    fBH_target = self._fBH_target[iout]
+                    # ------------------------------------------------------
+                    # Get BH natal kick statistics.
+                    # These are somewhat approximate, and also must be done
+                    # before the dynamical ejections so we can try to work out
+                    # how much mass was kicked before them.
+                    # ------------------------------------------------------
 
-                    # First remove mass from all bins by natal kicks, if desired
-                    #  Do it first because we dont control the exact amount so
-                    #  this could make the target fBH invalid afterwards
                     if self.natal_kicks:
-                        *_, self._kick_stats = kicks.natal_kicks(
-                            Mr.BH, Nr.BH, **self._kick_kw
-                        )
+
+                        # if not all BHs have formed yet, kick stats is invalid
+                        #  this is just due to how we now compute them using ibh
+                        if ((ti == self.tout[-1]) and (ti < self.ibh.age)):
+
+                            mssg = ("_kick_stats will not be valid for ages "
+                                    f"before all BHs form ({self.ibh.age} Myr)")
+                            warnings.warn(mssg)
+
+                        self._kick_stats = kicks.KickStats.from_final(
+                                Mr.BH, Nr.BH, self.ibh, parameters=self._kick_kw
+                            )
 
                     else:
+
                         self._kick_stats = kicks.KickStats.no_kicks(
                             self.massbins.nbin.BH
                         )
+
+                    # ------------------------------------------------------
+                    # Eject BHs dynamically, based on desired f_BH target
+                    # ------------------------------------------------------
+
+                    fBH_target = self._fBH_target[iout]
 
                     Mtot = np.r_[Mr].sum() + Ms.sum()
                     Mbhtot = Mr.BH.sum()
@@ -1252,14 +1328,23 @@ class EvolvedMFWithBH(EvolvedMF):
 
                     # can only make fBH go down by removing BHs
                     if fBH_target > fBH_current:
+
+                        if self.natal_kicks:
+                            nkwmssgs = ("; after natal kicks",
+                                        " or turn off / alter natal kicks")
+                        else:
+                            nkwmssgs = ("", "")
+
                         mssg = (
                             f"Target `f_BH` ({fBH_target}) is greater than "
-                            f"f_BH formed at t={ti:.1f} ({fBH_current:.3f}; "
-                            f"after natal kicks). Reduce `f_BH`, alter IMF "
-                            f"slopes or turn off / alter natal kicks."
+                            f"f_BH formed at t={ti:.1f} ({fBH_current:.3f}"
+                            f"{nkwmssgs[0]}). Reduce `f_BH` or alter IMF "
+                            f"slopes{nkwmssgs[1]}."
                         )
+
                         if self.strict_BH_target:
                             raise ValueError(mssg)
+
                         else:
                             # Will pass harmlessly through _dyn_eject_BH
                             mssg += (" Proceeding anyways due to "
@@ -1518,6 +1603,18 @@ class InitialBHPopulation:
         # Optionally perform natal kicks
         if natal_kicks:
 
+            # If f_kick, try to determine kick scale automatically
+            if f_kick is not None:
+                try:
+                    kick_slope, kick_scale = kicks._determine_kick_params(
+                        kick_method, f_kick, IMF, _ifmr,
+                        kick_slope, kick_scale
+                    )
+                except TypeError as err:
+                    mssg = (f"Can only use `f_kick` with methods that use "
+                            f"`scale` and `slope` params, not '{kick_method}'.")
+                    raise ValueError(mssg) from err
+
             match kick_method.casefold():
 
                 case 'maxwellian' | 'f12' | 'fryer2012':
@@ -1525,13 +1622,17 @@ class InitialBHPopulation:
                     from .ifmr import _check_IFMR_FeH_bounds
                     FeH_BH = _check_IFMR_FeH_bounds(FeH)
 
-                    kick_kw = dict(method=kick_method, f_kick=f_kick, vesc=vesc,
+                    kick_kw = dict(method=kick_method, vesc=vesc,
                                    FeH=FeH_BH, vdisp=kick_vdisp,
                                    SNe_method=SNe_method)
 
                 case 'sigmoid' | 'tanh':
-                    kick_kw = dict(method=kick_method, f_kick=f_kick,
+
+                    kick_kw = dict(method=kick_method,
                                    slope=kick_slope, scale=kick_scale)
+
+                case 'full' | 'everything' | 'all' | 'none':
+                    kick_kw = dict()
 
                 case _:
                     mssg = f"Invalid natal kick algorithm '{kick_method=}'"
@@ -1658,7 +1759,7 @@ class InitialBHPopulation:
 
         imf = PowerLawIMF(m_break=m_breaks, a=a_slopes, N0=N0, ext='zeros')
 
-        return cls.from_IMF(imf, nbins, FeH, N0=N0, natal_kicks=natal_kicks,
+        return cls.from_IMF(imf, FeH, nbins=nbins, natal_kicks=natal_kicks,
                             binning_breaks=binning_breaks,
                             binning_method=binning_method, **kwargs)
 
@@ -1735,4 +1836,3 @@ class InitialBHPopulation:
         N_BH, M_BH, _ = MF.binned_eval(bins)
 
         return cls(M_BH, N_BH, bins)
-

--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -1583,7 +1583,7 @@ class InitialBHPopulation:
 
             bins = massbins.bins.BH
 
-        nbin_BH = bins.lower.size
+        nbin_BH = len(bins.lower)
 
         # ------------------------------------------------------------------
         # Compute the initial amounts of BHs expected from the IMF and IFMR

--- a/ssptools/evolve_mf.py
+++ b/ssptools/evolve_mf.py
@@ -1590,11 +1590,16 @@ class InitialBHPopulation:
         # ------------------------------------------------------------------
 
         # Get domain of progenitor masses that make BHs
+        # TODO I could potentially get away with less point if logscaled mi
         mi = np.linspace(*_ifmr.BH_mi, 50_000)
         dm = mi[1] - mi[0]
 
         # Determine the final BH masses
         mf = _ifmr.predict(mi)
+
+        # Skip 0-mass remnants
+        mi = mi[mf > 0.0]
+        mf = mf[mf > 0.0]
 
         # Determine which BH bin each BH will fall into
         # TODO this may be behaving weird when out of bounds? (!)

--- a/ssptools/ifmr.py
+++ b/ssptools/ifmr.py
@@ -676,6 +676,8 @@ class IFMR:
     def predict_type(self, m_in):
         '''Predict the remnant type (WD, NS, BH) given the initial mass(es)'''
 
+        # TODO note that m_in=nan will always return a WD, should maybe error?
+
         rem_type = np.where(
             m_in >= self.BH_mi[0], 'BH',
             np.where(

--- a/ssptools/kicks.py
+++ b/ssptools/kicks.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from .ifmr import get_data
+from .evolve_mf import InitialBHPopulation
 
 import dataclasses
 
@@ -17,18 +18,79 @@ __all__ = ["kick_retention_fraction", "KickStats", "maxwellian_kick_v"]
 class KickStats:
     retention: np.ndarray
     mass_kicked: np.ndarray
+    num_kicked: np.ndarray
     parameters: dict
 
     @property
     def total_kicked(self) -> float:
+        '''The total amount of BH mass kicked.'''
         return self.mass_kicked.sum()
 
     @classmethod
     def no_kicks(cls, nmbin):
+        '''Kick stats when no kicks are applied.'''
         return cls(
             retention=np.ones(nmbin),
             mass_kicked=np.zeros(nmbin),
+            num_kicked=np.zeros(nmbin),
             parameters=dict()
+        )
+
+    @classmethod
+    def from_final(cls, Mr_BH, Nr_BH, ibh: InitialBHPopulation, parameters):
+        '''Compute the kick stats based on final BH arrays.
+
+        This constructor (the main one, likely) uses the final amounts of BHs,
+        after all kicks have been applied (but no other ejections have taken
+        place, e.g. no dynamical ejections), to compute the statistics based on
+        a corresponding `InitialBHPopulation` where the kicks have *not* been
+        applied.
+
+        This is done by simply assuming that all mass that is in the initial
+        BH population and not the given BH bins must have been natally kicked.
+
+        This will, at best, provide an approximately correct view of the kicks.
+        Any differences attributable to the binning effects in `Mr_BH` compared
+        to `InitialBHPopulation` will be especially notable, and may lead to
+        cases where, e.g., the kick amounts look very slightly negative.
+        There is unfortunately no better way to determine the effects of
+        natal kicks on the final BH bins themselves.
+
+        Also note that this *will not* be valid for cases where the BH bins
+        are created *before* the full amounts of BHs have been formed (i.e.
+        younger than `ibh.age`).
+
+        Parameters
+        ----------
+        Mr_BH : ndarray
+            Array[nbin] of the total final masses of black holes in each
+            BH mass bin, after natal kicks but before any other ejections.
+
+        Nr_BH : ndarray
+            Array[nbin] of the total final numbers of black holes in each
+            BH mass bin, after natal kicks but before any other ejections.
+
+        ibh : InitialBHPopulation
+            The `InitialBHPopulation` instance representing the expected
+            complete initial BH mass function. This must align exactly with
+            the BH bins, and must have been created with `natal_kicks=False`.
+
+        parameters : dict
+            The kick retention function parameters used, for convenient storage.
+        '''
+
+        retention = np.ones_like(Mr_BH)
+        c = ibh.M > 0
+        retention[c] = Mr_BH[c] / ibh.M[c]
+
+        M_kicked = ibh.M - Mr_BH
+        N_kicked = ibh.N - Nr_BH
+
+        return cls(
+            retention=retention,
+            mass_kicked=M_kicked,
+            num_kicked=N_kicked,
+            parameters=parameters
         )
 
 

--- a/ssptools/kicks.py
+++ b/ssptools/kicks.py
@@ -107,7 +107,7 @@ def _maxwellian_retention_frac(m, vesc, FeH, vdisp=265., *, SNe_method='rapid'):
     drawn from a Maxwellian distribution with a certain kick dispersion
     scaled down by a fallback fraction, as described by Fryer et al. (2012).
 
-    The fraction of black holes retained in each mass bin is then found by
+    The fraction of black holes retained is then found by
     integrating the kick velocity distribution from 0 to the estimated initial
     system escape velocity. In other words, by evaluating the CDF at the
     escape velocity.
@@ -116,6 +116,7 @@ def _maxwellian_retention_frac(m, vesc, FeH, vdisp=265., *, SNe_method='rapid'):
     ----------
     m : float
         The mean initial mass of the progenitor star which will make a BH.
+        Used to determine the fallback fraction.
 
     vesc : float
         The initial escape velocity of the cluster.
@@ -126,7 +127,7 @@ def _maxwellian_retention_frac(m, vesc, FeH, vdisp=265., *, SNe_method='rapid'):
 
     SNe_method : {'rapid', 'delayed', 'NS', 'none'}, optional
         Which method to use to determine the fallback fraction as a function of
-        the black hole mass, which scales the dispersion as σ(1-fb).
+        the initial mass, which scales the dispersion as σ(1-fb).
         Available methods include the "rapid" (default) or "delayed" supernovae
         prescriptions described by Fryer+2012, or the ratio of the neutron star
         to black hole mass.
@@ -226,7 +227,7 @@ def _sigmoid_retention_frac(m, slope, scale):
     r'''Retention fraction alg. based on a paramatrized sigmoid function.
 
     This method is based on a simple parametrization of the relationship
-    between the retention fraction and the BH mass as a sigmoid function,
+    between the retention fraction and the initial mass as a sigmoid function,
     increasing smoothly between 0 and 1 around a scale mass.
 
    .. math::
@@ -243,7 +244,8 @@ def _sigmoid_retention_frac(m, slope, scale):
         The "slope" of the sigmoid function, defining the "sharpness" of the
         increase. A value of 0 is completely flat (at fret=erf(1)~0.85), an
         increasingly positive value approaches a step function at the scale
-        mass, and a negative value will retain more low-mass bins than high.
+        mass, and a negative value will retain more low-mass progenitor BHs
+        than high.
 
     scale : float
         The scale-mass of the sigmoid function, defining the approximate mass
@@ -262,7 +264,7 @@ def _tanh_retention_frac(m, slope, scale):
     r'''Retention fraction alg. based on a paramatrized function of tanh.
 
     This method is based on a simple parametrization of the relationship
-    between the retention fraction and the BH mass as a sigmoid function,
+    between the retention fraction and the initial mass as a sigmoid function,
     namely the hyperbolic tangent, increasing smoothly between 0 and 1
     and reaching 50% at the given scale mass.
 
@@ -280,7 +282,8 @@ def _tanh_retention_frac(m, slope, scale):
         The "slope" of the sigmoid function, defining the "sharpness" of the
         increase. A value of 0 is completely flat (at 50% for all masses), an
         increasingly positive value approaches a step function at the scale
-        mass, and a negative value will retain more low-mass bins than high.
+        mass, and a negative value will retain more low-mass progenitor BHs
+        than high.
 
     scale : float
         The scale-mass of the sigmoid function, defining the approximate mass
@@ -295,99 +298,79 @@ def _tanh_retention_frac(m, slope, scale):
     # return np.tanh(np.exp(slope * (m - scale)))  # alternative
 
 
-def kick_retention_fraction(m_ini, f_kick=None, method='fryer2012', **ret_kwargs):
-    '''
+def kick_retention_fraction(m_ini, method='fryer2012', **ret_kwargs):
+    r'''Compute the retention fraction of BH natal-kicks from progenitor masses
 
-    m_ini : float
+    Determines the effects of BH natal-kicks, in the form of a retention
+    fraction to be used when creating the BH masses, based on the given natal
+    kick algorithm.
+
+    Various natal kick algorithms are currently available. All methods require
+    different arguments, which can be passed to `ret_kwargs`.
+    See the respective retention functions for details on these arguments and
+    the algorithms themselves.
+
+    Parameters
+    ----------
+    m_ini : float or ndarray[float]
         The initial (ZAMS) mass of the progenitor star which will form a BH.
+        Is passed to the requested retention fraction function.
+
+    method : {'sigmoid', 'tanh', 'maxwellian'}, optional
+        Natal kick algorithm to use, defining the retention fraction as a
+        function of mean bin mass. Defaults to the Maxwellian method.
+
+    **ret_kwargs : dict, optional
+        All other arguments are passed to the retention fraction function.
+
+    Returns
+    -------
+    f_rem : float
+        The retention fraction of the BH created by this input progenitor mass.
+
+    See Also
+    --------
+    _maxwellian_retention_frac : Maxwellian retention fraction algorithm.
+    _sigmoid_retention_frac : Sigmoid retention fraction algorithm.
+    _tanh_retention_frac : Hyperbolic tangent retention fraction algorithm.
     '''
 
     f_ret = _get_kick_method(method)
 
-    # If no given total kick fraction, use old-style of directly using f_ret
-    if f_kick is None:
-
-        return f_ret(m_ini, **ret_kwargs)
-
-        # return _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, **ret_kwargs)
-
-    else:
-        raise NotImplementedError('TODO')
-
-        # get the BHMF using the new fast InitialBHPopulation and then do this
-
-        # # Fit for the desired kick scale
-        # try:
-        #     slp, scl = _determine_kick_params(Mr_BH, Nr_BH, f_ret, f_kick,
-        #                                       **ret_kwargs)
-        # except TypeError as err:
-        #     mssg = (f"Can only use `f_kick` with methods that use a `scale` and"
-        #             f" `slope` parameter, not '{method}'.")
-        #     raise ValueError(mssg) from err
-
-        # # Compute the natal kicks based on fit scale
-        return _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, slope=slp, scale=scl)
+    return f_ret(m_ini, **ret_kwargs)
 
 
-
-# --------------------------------------------------------------------------
-# Performing natal kicks on BH mass functions
-# --------------------------------------------------------------------------
-
-
-def _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, **ret_kwargs):
-
-    c = Nr_BH > 0.1
-    mr_BH = Mr_BH[c] / Nr_BH[c]
-    natal_ejecta = np.zeros_like(Mr_BH)
-    retention = np.full_like(Mr_BH, np.nan)
-
-    retention[c] = f_ret(mr_BH, **ret_kwargs)
-
-    # keep track of how much we eject
-    natal_ejecta[c] = Mr_BH[c] * (1 - retention[c])
-
-    Mr_BH[c] *= retention[c]
-    Nr_BH[c] *= retention[c]
-
-    stats = KickStats(
-        retention=retention, mass_kicked=natal_ejecta, parameters=ret_kwargs
-    )
-
-    return Mr_BH, Nr_BH, stats
-
-
-def _determine_kick_params(Mr_BH, Nr_BH, f_ret, f_target, slope, scale=10.):
-    '''
-    Use a root finding algorithm to determine the value of `scale` needed in
-    order to eject a total fraction of the given BHs `f_target`, using the
-    given `f_ret` function to distribute the kicks among mass bins.
-    Note that while it says "params", right now can only compute the scale.
-    '''
+def _determine_kick_params(method, f_target, IMF, IFMR, slope, scale=10.):
     import scipy.optimize as opt
 
-    c = Nr_BH > 0.1
+    f_ret = _get_kick_method(method)
 
-    m_BH = Mr_BH[c] / Nr_BH[c]
-    M_BH_tot = Mr_BH.sum()
+    # Get domain of progenitor masses that make BHs
+    mi = np.linspace(*IFMR.BH_mi, 50_000)
+    dm = mi[1] - mi[0]
 
-    f_ini = Mr_BH[c] / M_BH_tot
+    # Determine the final BH masses
+    mf = IFMR.predict(mi)
 
-    # f_ret = _tanh_retention_frac
+    M_BH_tot_ini = np.sum(mf * IMF.N(mi) * dm)
 
     # Keep first guess on optionally given scale
     scale = scale if scale is not None else 10.0
 
     def target_fret(scl):
 
-        retention = f_ret(m_BH, scale=scl, slope=slope)
+        retention = f_ret(mi, scale=scl, slope=slope)
 
-        f_BH_final = (f_ini * (1 - retention)).sum(axis=0)
+        M_BH_tot = np.sum(retention * mf * IMF.N(mi) * dm)
+
+        f_BH_final = 1 - (M_BH_tot / M_BH_tot_ini)
 
         return f_target - f_BH_final
 
     try:
-        sol = opt.root_scalar(target_fret, x0=scale, bracket=(-25, 75))
+        sol = opt.root_scalar(target_fret, x0=scale,
+                              bracket=(-25, IFMR.BH_mi.upper + 25))
+
     except ValueError as err:
         mssg = ("Root finder failed to find scale parameter matching target "
                 f"{f_target}. 'f_target' or 'slope' need to be adjusted.")
@@ -425,101 +408,6 @@ def _get_kick_method(method):
             raise ValueError(f"Invalid kick distribution method: {method}")
 
     return f_ret
-
-
-def natal_kicks(Mr_BH, Nr_BH, f_kick=None, method='fryer2012', **ret_kwargs):
-    r'''Computes the effects of BH natal-kicks on the mass and number of BHs
-
-    Determines the effects of BH natal-kicks, and distributes said kicks
-    throughout the different BH mass bins, based on the given natal kick
-    algorithm. In general, BHs are preferentially lost in the low mass
-    bins, with the lowest masses being entirely kicked, and the highest masses
-    being entirely retained.
-
-    Two natal kick algorithms are currently available. Both methods require
-    different arguments, which can be passed to `ret_kwargs`.
-    See the respective retention functions for details on these arguments.
-
-    The first is based on the assumption that the kick velocity is drawn from
-    a Maxwellian distribution with a certain kick dispersion (scaled down by
-    a “fallback fraction” interpolated from a grid of SSE models). The
-    fraction of black holes retained in each mass bin is then found by
-    integrating the kick velocity distribution from 0 to the estimated initial
-    system escape velocity. See Fryer et al. (2012) for more information.
-
-    A second, more directly flexible method is not based on any modelled BH
-    physics, but simply determines the retention fraction of BHs in each bin
-    based on the simple sigmoid function
-    :math:`f_{ret}(m)=\operatorname{erf}\left(e^{a(m-b)}\right)`.
-
-    Both input BH arrays are modified *in place*, as well as returned.
-
-    Parameters
-    ----------
-    Mr_BH : ndarray
-        Array[nbin] of the total initial masses of black holes in each
-        BH mass bin.
-
-    Nr_BH : ndarray
-        Array[nbin] of the total initial numbers of black holes in each
-        BH mass bin.
-
-    f_kick : float, optional
-        Unused.
-
-    method : {'sigmoid', 'maxwellian'}, optional
-        Natal kick algorithm to use, defining the retention fraction as a
-        function of mean bin mass. Defaults to the Maxwellian method.
-
-    **ret_kwargs : dict, optional
-        All other arguments are passed to the retention fraction function.
-
-    Returns
-    -------
-    Mr_BH : ndarray
-        Array[nbin] of the total final masses of black holes in each
-        BH mass bin, after natal kicks.
-
-    Nr_BH : ndarray
-        Array[nbin] of the total final numbers of black holes in each
-        BH mass bin, after natal kicks.
-
-    stats : KickStats
-        Statistics on how and how many BHs are kicked.
-
-    Notes
-    -----
-    This was the old method of applying natal kicks, when the ejections of BHs
-    were only considered after generating all of the masses. This relied on
-    faulty logic w.r.t. the fallback fractions and are no longer used, but left
-    here for posterity. This method is still valid for non-Maxwellian kicks.
-
-    See Also
-    --------
-    _maxwellian_retention_frac : Maxwellian retention fraction algorithm.
-    _sigmoid_retention_frac : Sigmoid retention fraction algorithm.
-    _tanh_retention_frac : Hyperbolic tangent retention fraction algorithm.
-    '''
-
-    f_ret = _get_kick_method(method)
-
-    # If no given total kick fraction, use old-style of directly using f_ret
-    if f_kick is None:
-        return _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, **ret_kwargs)
-
-    else:
-
-        # Fit for the desired kick scale
-        try:
-            slp, scl = _determine_kick_params(Mr_BH, Nr_BH, f_ret, f_kick,
-                                              **ret_kwargs)
-        except TypeError as err:
-            mssg = (f"Can only use `f_kick` with methods that use a `scale` and"
-                    f" `slope` parameter, not '{method}'.")
-            raise ValueError(mssg) from err
-
-        # Compute the natal kicks based on fit scale
-        return _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, slope=slp, scale=scl)
 
 
 # --------------------------------------------------------------------------

--- a/ssptools/kicks.py
+++ b/ssptools/kicks.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from .ifmr import get_data
-from .evolve_mf import InitialBHPopulation
 
 import dataclasses
 
@@ -37,7 +36,7 @@ class KickStats:
         )
 
     @classmethod
-    def from_final(cls, Mr_BH, Nr_BH, ibh: InitialBHPopulation, parameters):
+    def from_final(cls, Mr_BH, Nr_BH, ibh, parameters):
         '''Compute the kick stats based on final BH arrays.
 
         This constructor (the main one, likely) uses the final amounts of BHs,

--- a/ssptools/kicks.py
+++ b/ssptools/kicks.py
@@ -10,7 +10,7 @@ from scipy.special import erf, gammaincinv
 import scipy.interpolate as interp
 
 
-__all__ = ["natal_kicks", "KickStats", "maxwellian_kick_v"]
+__all__ = ["kick_retention_fraction", "KickStats", "maxwellian_kick_v"]
 
 
 @dataclasses.dataclass(eq=False, frozen=True)
@@ -53,7 +53,7 @@ def _maxwellian_retention_frac(m, vesc, FeH, vdisp=265., *, SNe_method='rapid'):
     Parameters
     ----------
     m : float
-        The mean mass of a BH bin.
+        The mean initial mass of the progenitor star which will make a BH.
 
     vesc : float
         The initial escape velocity of the cluster.
@@ -73,7 +73,7 @@ def _maxwellian_retention_frac(m, vesc, FeH, vdisp=265., *, SNe_method='rapid'):
     Returns
     -------
     float
-        The retention fraction of BHs of this mass.
+        The retention fraction of BHs created by stars of this mass.
 
     '''
 
@@ -137,11 +137,10 @@ def _F12_fallback_frac(FeH, *, model='uSSE', SNe_method='rapid'):
     # feh_path = get_data(f"sse/MP_FEH{FeH:+.2f}.dat")  # .2f snaps to the grid
     feh_path = get_data(f"ifmr/{model}_{SNe_method}/IFMR_FEH{FeH:+.2f}.dat")
 
-    # load in the data (only final remnant mass and fbac)
-    fb_grid = np.loadtxt(feh_path, usecols=(1, 3), unpack=True)
+    # load in the data (only initial star mass and fbac)
+    fb_grid = np.loadtxt(feh_path, usecols=(0, 3), unpack=True)
 
-    # TODO this is incorrect, and should be a function of mi
-    # Interpolate the mr-fb grid
+    # Interpolate the mi-fb grid
     return interp.interp1d(fb_grid[0], fb_grid[1], kind="linear",
                            bounds_error=False, fill_value=(0.0, 1.0))
 
@@ -176,7 +175,7 @@ def _sigmoid_retention_frac(m, slope, scale):
     Parameters
     ----------
     m : float
-        The mean mass of a BH bin.
+        The mean initial mass of the progenitor star which will make a BH.
 
     slope : float
         The "slope" of the sigmoid function, defining the "sharpness" of the
@@ -192,7 +191,7 @@ def _sigmoid_retention_frac(m, slope, scale):
     Returns
     -------
     float
-        The retention fraction of BHs of this mass.
+        The retention fraction of BHs created by stars of this mass.
     '''
     return erf(np.exp(slope * (m - scale)))
 
@@ -213,7 +212,7 @@ def _tanh_retention_frac(m, slope, scale):
     Parameters
     ----------
     m : float
-        The mean mass of a BH bin.
+        The mean initial mass of the progenitor star which will make a BH.
 
     slope : float
         The "slope" of the sigmoid function, defining the "sharpness" of the
@@ -228,10 +227,45 @@ def _tanh_retention_frac(m, slope, scale):
     Returns
     -------
     float
-        The retention fraction of BHs of this mass.
+        The retention fraction of BHs created by stars of this mass.
     '''
     return 0.5 * (np.tanh(slope * (m - scale)) + 1)
     # return np.tanh(np.exp(slope * (m - scale)))  # alternative
+
+
+def kick_retention_fraction(m_ini, f_kick=None, method='fryer2012', **ret_kwargs):
+    '''
+
+    m_ini : float
+        The initial (ZAMS) mass of the progenitor star which will form a BH.
+    '''
+
+    f_ret = _get_kick_method(method)
+
+    # If no given total kick fraction, use old-style of directly using f_ret
+    if f_kick is None:
+
+        return f_ret(m_ini, **ret_kwargs)
+
+        # return _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, **ret_kwargs)
+
+    else:
+        raise NotImplementedError('TODO')
+
+        # get the BHMF using the new fast InitialBHPopulation and then do this
+
+        # # Fit for the desired kick scale
+        # try:
+        #     slp, scl = _determine_kick_params(Mr_BH, Nr_BH, f_ret, f_kick,
+        #                                       **ret_kwargs)
+        # except TypeError as err:
+        #     mssg = (f"Can only use `f_kick` with methods that use a `scale` and"
+        #             f" `slope` parameter, not '{method}'.")
+        #     raise ValueError(mssg) from err
+
+        # # Compute the natal kicks based on fit scale
+        return _unbound_natal_kicks(Mr_BH, Nr_BH, f_ret, slope=slp, scale=scl)
+
 
 
 # --------------------------------------------------------------------------
@@ -390,6 +424,13 @@ def natal_kicks(Mr_BH, Nr_BH, f_kick=None, method='fryer2012', **ret_kwargs):
 
     stats : KickStats
         Statistics on how and how many BHs are kicked.
+
+    Notes
+    -----
+    This was the old method of applying natal kicks, when the ejections of BHs
+    were only considered after generating all of the masses. This relied on
+    faulty logic w.r.t. the fallback fractions and are no longer used, but left
+    here for posterity. This method is still valid for non-Maxwellian kicks.
 
     See Also
     --------

--- a/ssptools/masses.py
+++ b/ssptools/masses.py
@@ -117,8 +117,7 @@ class PowerLawIMF:
     def Mtot(self):
         '''Total mass of system under this IMF (assuming `self.N0` stars).'''
         # TODO integrating this every time is wasteful
-        from scipy.integrate import quad
-        return quad(self.M, self.mb[0], self.mb[-1])[0]
+        return self.integrate_M(self.mb[0], self.mb[-1])
 
     @classmethod
     def from_M0(cls, m_break, a, M0, *, ext='zeros'):
@@ -302,6 +301,14 @@ class PowerLawIMF:
     def binned_M(self, bins, *, N=None):
         '''Return the total mass of stars within given mass bins.'''
         return self.binned_eval(bins=bins, N=N)[1]
+
+    def integrate_N(self, ml, mu):
+        from scipy.integrate import quad
+        return quad(self.N, ml, mu)[0]
+
+    def integrate_M(self, ml, mu):
+        from scipy.integrate import quad
+        return quad(self.M, ml, mu)[0]
 
 
 # --------------------------------------------------------------------------

--- a/ssptools/masses.py
+++ b/ssptools/masses.py
@@ -808,6 +808,10 @@ class MassBins:
         if massbins in star_classes._fields:
             massbins = getattr(self.bins, massbins)
 
+        # TODO I think you can replace this entire thing with just
+        # ind = np.digitize(mass, bin_edges, right=False) - 1
+        # That is vectorized and clearer.
+
         # Since mass bins always increasing, can look at only the lower bound
         try:
             ind = np.flatnonzero(massbins.lower <= mass)[-1]

--- a/ssptools/masses.py
+++ b/ssptools/masses.py
@@ -547,6 +547,7 @@ class MassBins:
             bins_BH = mbin(bins_MS.lower[BH_mask].copy(),
                            bins_MS.upper[BH_mask].copy())
             bins_BH.lower[0] = ifmr.BH_mf.lower
+            bins_BH.upper[-1] = ifmr.BH_mf.upper
 
             # Neutron Stars
 

--- a/tests/test_evolve_mf.py
+++ b/tests/test_evolve_mf.py
@@ -19,7 +19,7 @@ DEFAULT_IMF = masses.PowerLawIMF(
 # TODO need a test for when multiple tout, as that can be unstable.
 DEFAULT_KWARGS = dict(
     IMF=DEFAULT_IMF, nbins=[5, 5, 20], FeH=-1.00, tout=[12_000], esc_rate=0.,
-    N0=5e5, tcc=0.0, NS_ret=0.1, BH_ret_int=1.0, BH_ret_dyn=1.0,
+    N0=5e5, tcc=0.0, NS_ret=0.1, BH_ret_dyn=1.0,
     natal_kicks=False, vesc=90
 )
 
@@ -376,3 +376,108 @@ class TestDerivatives:
 
         ydot = emf._derivs_esc(t, y)
         assert ydot == pytest.approx(expected)
+
+
+
+class TestInitialBHPopulation:
+
+    bins = masses.mbin(lower=[0.1, 5.0, 10.0, 20.0, 50.],
+                       upper=[5.0, 10.0, 20.0, 50., 150])
+
+    ibh_kw = dict(IMF=DEFAULT_IMF, natal_kicks=False, bins=bins)
+
+    # ----------------------------------------------------------------------
+    # Initialization routines
+    # ----------------------------------------------------------------------
+
+    # def test_from_bhmf
+
+    @pytest.mark.parametrize('FeH', [-2, -1.5, -1, -0.5, 0.0])
+    def test_from_imf(self, FeH):
+
+        # Initialize Initial BH Population
+
+        ibh = evolve_mf.InitialBHPopulation.from_IMF(FeH=FeH, **self.ibh_kw)
+
+        # Recompute the amounts of BHs
+
+        _ifmr = ifmr.IFMR(FeH=FeH)
+
+        mi = np.linspace(*_ifmr.BH_mi, 500_000)  # use high resolution
+        dm = mi[1] - mi[0]
+
+        # Determine the final BH masses
+        mf = _ifmr.predict(mi)
+
+        # Skip 0-mass remnants
+        mi = mi[mf > 0.0]
+        mf = mf[mf > 0.0]
+
+        Nbins = len(self.bins.lower)
+
+        inds = np.digitize(mf, np.r_[self.bins.lower, self.bins.upper[-1]]) - 1
+
+        # natal kicks off, no frem term
+        expected_MBH = np.bincount(inds, weights=mf * DEFAULT_IMF.N(mi) * dm,
+                                   minlength=Nbins)
+
+        expected_NBH = np.bincount(inds, weights=DEFAULT_IMF.N(mi) * dm,
+                                   minlength=Nbins)
+
+        assert ibh.M == pytest.approx(expected_MBH, rel=0.01)
+        assert ibh.N == pytest.approx(expected_NBH, rel=0.01)
+
+    # ----------------------------------------------------------------------
+    # Properties and attributes
+    # ----------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        'FeH, expected_Mtot',
+        [
+            (-2, 21843.38486),
+            (-1.5, 20827.24313),
+            (-1, 17298.61685),
+            (-0.5, 14599.08499),
+            (0.0, 7491.10354)
+        ],
+    )
+    def test_Mtot(self, FeH, expected_Mtot):
+        ibh = evolve_mf.InitialBHPopulation.from_IMF(FeH=FeH, **self.ibh_kw)
+
+        assert ibh.Mtot == pytest.approx(expected_Mtot, rel=0.001)
+
+    @pytest.mark.parametrize(
+        'FeH, expected_age',
+        [
+            (-2, 8.85291),
+            (-1.5, 8.67542),
+            (-1, 8.46274),
+            (-0.5, 8.10353),
+            (0.0, 7.55464)
+        ],
+    )
+    def test_age(self, FeH, expected_age):
+        ibh = evolve_mf.InitialBHPopulation.from_IMF(FeH=FeH, **self.ibh_kw)
+
+        assert ibh.age == pytest.approx(expected_age, rel=0.0001)
+
+    @pytest.mark.parametrize(
+        'FeH, expected_Ms_lost',
+        [
+            (-2, 44383.71036),
+            (-1.5, 43786.47009),
+            (-1, 43010.53556),
+            (-0.5, 42071.81981),
+            (0.0, 39949.14502)
+        ],
+    )
+    def test_Ms_lost(self, FeH, expected_Ms_lost):
+        ibh = evolve_mf.InitialBHPopulation.from_IMF(FeH=FeH, **self.ibh_kw)
+
+        assert ibh.Ms_lost == pytest.approx(expected_Ms_lost, rel=0.0001)
+
+
+
+
+
+

--- a/tests/test_kicks.py
+++ b/tests/test_kicks.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python
 
+import dataclasses
+
 import pytest
 import numpy as np
 import scipy.special
 import scipy.integrate as integ
 
-from ssptools import kicks
+from ssptools import kicks, evolve_mf, masses, ifmr
+
+
+DEFAULT_M_BREAK = [0.1, 0.5, 1.0, 100]
+
+DEFAULT_IMF = masses.PowerLawIMF(
+    m_break=DEFAULT_M_BREAK, a=[-0.5, -1.3, -2.5], N0=5e5
+)
+
+DEFAULT_IFMR = ifmr.IFMR(FeH=-1)
 
 
 class TestRetentionAlgorithms:
@@ -83,192 +94,52 @@ class TestRetentionAlgorithms:
 
         assert fret == pytest.approx(value)
 
-
-class TestNatalKicks:
-
-    # TODO these aren't really representative m_BH (m=M/N=.5,1,2)
-    @pytest.fixture()
-    def Mi(self):
-        return np.array([10., 10., 10.])
-
-    @pytest.fixture()
-    def Ni(self):
-        return np.array([20., 10., 5.])
-
-    # ----------------------------------------------------------------------
-    # Test Maxwellian / Fryer+2012 natal kick algorithms
-    # ----------------------------------------------------------------------
-
     @pytest.mark.parametrize(
-        'FeH, vesc, expected',
+        'mi, rem_type, expected_frem',
         [
-            (-1., 25., np.stack((np.array([0.002227, 0.002227, 0.002810]),
-                                 np.array([0.004454, 0.002227, 0.001405])))),
-            (-1., 100., np.stack((np.array([0.136963, 0.136963, 0.171672]),
-                                  np.array([0.273926, 0.136963, 0.085836])))),
-            (-1., 200., np.stack((np.array([0.966443, 0.966443, 1.186696]),
-                                  np.array([1.932887, 0.966443, 0.593348])))),
-            (0.3, 25., np.stack((np.array([0.002227, 0.002227, 0.002727]),
-                                 np.array([0.004454, 0.002227, 0.001363])))),
-            (0.3, 100., np.stack((np.array([0.136963, 0.136963, 0.166788]),
-                                  np.array([0.273926, 0.136963, 0.08339])))),
-            (0.3, 200., np.stack((np.array([0.966443, 0.966443, 1.156175]),
-                                  np.array([1.932887, 0.966443, 0.578087]))))
+            (0.5, 'WD', 1.0),
+            (1.0, 'WD', 1.0),
+            (1.4, 'NS', 0.1),
+            (5.0, 'BH', 0.01006),
+            (10.0, 'BH', 0.01006,),
+            (20.0, 'BH', 0.01229),
+            (50.0, 'BH', 1.0),
+            (100.0, 'BH', 1.0)
         ],
     )
-    def test_F12_kicks_quantities(self, Mi, Ni, FeH, vesc, expected):
+    def test_frem(self, mi, rem_type, expected_frem):
 
-        Mf, Nf, _ = kicks.natal_kicks(Mi, Ni, method='F12', FeH=FeH, vesc=vesc)
+        @dataclasses.dataclass
+        class SpoofEMF:
+            NS_ret = 0.1
+            natal_kicks = True
+            _kick_kw = dict(FeH=-1, method='fryer2012', vesc=90)
 
-        assert np.stack((Mf, Nf)) == pytest.approx(expected, rel=1e-3)
+        frem = evolve_mf.EvolvedMF._frem(SpoofEMF(), mi, rem_type)
 
-    @pytest.mark.parametrize(
-        'FeH, vesc, expected',
-        [
-            (-1., 25., 29.992735),
-            (-1., 100., 29.554400),
-            (-1., 200., 26.880415),
-            (0.3, 25., 29.992818),
-            (0.3, 100., 29.559284),
-            (0.3, 200., 26.910936),
-        ],
-    )
-    def test_F12_kicks_total(self, Mi, Ni, FeH, vesc, expected):
-
-        _, _, ks = kicks.natal_kicks(Mi, Ni, method='F12', FeH=FeH, vesc=vesc)
-
-        assert ks.total_kicked == pytest.approx(expected, rel=1e-3)
-
-    # ----------------------------------------------------------------------
-    # Test sigmoid natal kick algorithm
-    # ----------------------------------------------------------------------
+        assert frem == pytest.approx(expected_frem, abs=0.0001)
 
     @pytest.mark.parametrize(
-        'slope, scale, expected',
+        'f_target, expected_scale',
         [
-            (0.5, 0., np.stack((np.array([9.306121, 9.802805, 9.998790]),
-                                np.array([18.612243, 9.802805, 4.999395])))),
-            (0.5, 20., np.stack((np.array([0.000657, 0.000844, 0.001392]),
-                                 np.array([0.001315, 0.000844, 0.000696])))),
-            (0.5, 50., np.stack((np.array([0.0, 0.0, 0.0]),
-                                 np.array([0.0, 0.0, 0.0])))),
-            (10, 0., np.stack((np.array([10., 10., 10.]),
-                               np.array([20., 10., 5.])))),
-            (10, 20., np.stack((np.array([0.0, 0.0, 0.0]),
-                                np.array([0.0, 0.0, 0.0])))),
-            (10, 50., np.stack((np.array([0.0, 0.0, 0.0]),
-                                np.array([0.0, 0.0, 0.0])))),
+            (0.001, 16.24579),
+            (0.1, 21.66143),
+            (0.5, 35.07088),
+            (0.8, 62.84709),
+            (0.99, 97.70552)
         ],
     )
-    def test_sigmoid_kicks_quantities(self, Mi, Ni, slope, scale, expected):
+    def test_determine_params(self, f_target, expected_scale):
 
-        Mf, Nf, _ = kicks.natal_kicks(Mi, Ni, method='sigmoid',
-                                      slope=slope, scale=scale)
+        _, scale = kicks._determine_kick_params(
+            method='tanh',
+            f_target=f_target,
+            IMF=DEFAULT_IMF,
+            IFMR=DEFAULT_IFMR,
+            slope=0.5
+        )
 
-        assert np.stack((Mf, Nf)) == pytest.approx(expected, abs=1e-3)
-
-    @pytest.mark.parametrize(
-        'slope, scale, expected',
-        [
-            (0.5, 0, 0.892281),
-            (0.5, 20, 29.997105),
-            (0.5, 50, 29.999999),
-            (10, 0, 0.0),
-            (10, 20, 30.0),
-            (10, 50, 30.0)
-        ],
-    )
-    def test_sigmoid_kicks_total(self, Mi, Ni, slope, scale, expected):
-
-        _, _, ks = kicks.natal_kicks(Mi, Ni, method='sigmoid',
-                                     slope=slope, scale=scale)
-
-        assert ks.total_kicked == pytest.approx(expected, rel=1e-3)
-
-    # ----------------------------------------------------------------------
-    # Test tanh natal kick algorithm
-    # ----------------------------------------------------------------------
-
-    @pytest.mark.parametrize(
-        'slope, scale, expected',
-        [
-            (0.5, 0., np.stack((np.array([6.224593, 7.310585, 8.807970]),
-                                np.array([12.449186, 7.310585, 4.403985])))),
-            (0.5, 20., np.stack((np.array([3.3982e-08, 5.6027e-08, 1.5229e-07]),
-                                np.array([6.7965e-08, 5.603e-08, 7.615e-08])))),
-            (0.5, 50., np.stack((np.array([0., 0., 0.]),
-                                np.array([0., 0., 0.])))),
-            (10., 0., np.stack((np.array([9.999546, 9.999999, 10.]),
-                                np.array([19.999092, 9.999999, 5.])))),
-            (10., 20., np.stack((np.array([0., 0., 0.]),
-                                np.array([0., 0., 0.])))),
-            (10., 50., np.stack((np.array([0., 0., 0.]),
-                                np.array([0., 0., 0.]))))
-        ],
-    )
-    def test_tanh_kicks_quantities(self, Mi, Ni, slope, scale, expected):
-
-        Mf, Nf, _ = kicks.natal_kicks(Mi, Ni, method='tanh',
-                                      slope=slope, scale=scale)
-
-        assert np.stack((Mf, Nf)) == pytest.approx(expected, abs=1e-3)
-
-    @pytest.mark.parametrize(
-        'slope, scale, expected',
-        [
-            (0.5, 0, 7.65685),
-            (0.5, 20, 29.99999),
-            (0.5, 50, 30.0),
-            (10, 0, 0.000454),
-            (10, 20, 30.0),
-            (10, 50, 30.0)
-        ],
-    )
-    def test_tanh_kicks_total(self, Mi, Ni, slope, scale, expected):
-
-        _, _, ks = kicks.natal_kicks(Mi, Ni, method='tanh',
-                                     slope=slope, scale=scale)
-
-        assert ks.total_kicked == pytest.approx(expected, rel=1e-3)
-
-    # ----------------------------------------------------------------------
-    # Test natal kick algorithm when explicitly specifying f_kick
-    # ----------------------------------------------------------------------
-
-    @pytest.mark.parametrize(
-        'slope, f_kick, expected',
-        [
-            (0.5, 0.1, np.stack((np.array([8.421878, 8.979450, 9.598670]),
-                                 np.array([16.843757, 8.979450, 4.799335])))),
-            (0.5, 0.5, np.stack((np.array([3.40972, 4.603431, 6.986839]),
-                                 np.array([6.819459, 4.603431, 3.493419])))),
-            (0.5, 0.9, np.stack((np.array([0.464521, 0.743462, 1.792015]),
-                                 np.array([0.929043, 0.743462, 0.896007])))),
-            (10., 0.1, np.stack((np.array([7.000194, 9.999805, 10.]),
-                                 np.array([14.00038, 9.999805, 5.])))),
-            (10., 0.5, np.stack((np.array([4.5389e-04, 4.999546, 9.999999]),
-                                 np.array([9.0779e-04, 4.999546, 4.999999])))),
-            (10., 0.9, np.stack((np.array([4.0134e-13, 8.8335e-09, 2.999999]),
-                                 np.array([8.0269e-13, 8.8335e-09, 1.500000]))))
-        ],
-    )
-    def test_expl_fkick_kicks_quantities(self, Mi, Ni, slope, f_kick, expected):
-
-        Mf, Nf, _ = kicks.natal_kicks(Mi, Ni, method='tanh', f_kick=f_kick,
-                                      slope=slope)
-
-        assert np.stack((Mf, Nf)) == pytest.approx(expected, abs=1e-3)
-
-    @pytest.mark.parametrize('slope', [0.5, 10.])
-    @pytest.mark.parametrize('f_kick', [0.1, 0.5, 0.9])
-    def test_expl_fkick_kicks_total(self, Mi, Ni, slope, f_kick):
-
-        expected = f_kick * Mi.sum()
-
-        _, _, ks = kicks.natal_kicks(Mi, Ni, method='tanh', f_kick=f_kick,
-                                     slope=slope)
-
-        assert ks.total_kicked == pytest.approx(expected, rel=1e-3)
+        assert scale == pytest.approx(expected_scale, abs=0.0001)
 
 
 class TestKickVelocities:


### PR DESCRIPTION
This is a major redesign of how BH natal kicks are handled in SSPtools, motivated by a bug that was found during #17.

Originally (and for the entire history of the package) the BH natal kicks were computed (by default) based on fallback fractions which were being _incorrectly_ interpolated from a function of BH-mass vs fallback. In reality, this should be a function of _initial_ progenitor star mass, not BH mass.

This was probably originally done because the kicks were applied after-the-fact (same as the dynamical BH ejections) where you have only the final BH mass bins, and can compute these quantities.

In order to change all kick functions to be based on the initial mass, how the kicks are handled thus had to be changed entirely. Now, rather than computing and applying them after the solver is finished, the natal kicks are instead applied as retention fractions to the amount of BH mass formed at a given timestep.
This is the same way that e.g. NS kicks and the unused `BH_ret_int` were used originally.

This means that not all BHs in a given mass bin share the same retention function, and the incorrect fb-interpolation now no longer causes zero BHs in slightly larger BH mass bins to be ejected.


This is a major change under the hood, and comes with various "user-facing" side effects that make this somewhat backwards-incompatible (and thus a new major release).

1. The natal kick stats `KickStats` (stored as `emf._kick_stats`) are no longer easy to compute (as we no longer kick BHs based on the BH bins, which these stats are a function of). The new way of computing them, by trying to autopsy the final results with and without kicks, are approximate at best, and can show non-physical results based on age and binning effects. Therefore they were made less relevant, and are only provided now as they are interesting to inspect. They should be actually used with caution.

2. To stop needing the kick stats, the definition of the `BH_ret_dyn` parameter had to change. Now it *only* represents the retention function of BHs from _dynamical ejections_, not natal kicks as well. Similarly, the `BH_ret_int` parameter is entirely removed (replaced by the natal kicks themselves). This was likely actually the original intended use of this parameter, based on its name. This change **is not backwards compatible**, obviously.

3. The `InitialBHPopulation` class is more important now, as in various places it can be useful to know how many BHs would form in total. To facilitate this, the class is vastly improved, and now based simply on going from IMF through IFMR to BHMF, rather than actually solving a binned ODE. It is much (100x) faster now, but also **not backwards compatible**.

And of course the most obvious change is that new models, run with entirely the same parameters, will have different amounts of final BHs (slightly lower), simply due to the fixes to the natal kicks.